### PR TITLE
Publish docker image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,49 @@
+# heavily inspired by https://actuated.dev/blog/multi-arch-docker-github-actions
+name: publish
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  publish:
+    permissions:
+      packages: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Get Ref Name
+        run: echo REF_NAME=${GITHUB_REF_NAME/\//-} >> $GITHUB_ENV
+      - name: Get Repo Owner
+        run: echo "REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" > $GITHUB_ENV
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to container Registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v4
+        with:
+          outputs: "type=registry,push=true"
+          provenance: false
+          platforms: linux/amd64,linux/arm64/v8
+          build-args: |
+            Version=${{ env.REF_NAME }}
+            GitCommit=${{ github.sha }}
+          tags: |
+            ghcr.io/${{ env.REPO_OWNER }}/openmower-mapeditor:${{ github.sha }}
+            ghcr.io/${{ env.REPO_OWNER }}/openmower-mapeditor:${{ env.REF_NAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,6 @@ RUN pip3 install -r requirements.txt
 
 ADD app /usr/src/app
 
+EXPOSE 5000
+
 CMD ["python3", "app.py", "/map/map.bag"]

--- a/README.md
+++ b/README.md
@@ -17,3 +17,21 @@ Quick and dirty map editor for [Openmower](https://openmower.de/)
 - Split areas
 - Snap on grid
 - Display coordinates
+
+# Running
+
+Execute the following command to run the map editor on the OpenMower system:
+
+```
+sudo podman run --replace --detach --tty \
+  --name openmower-mapeditor \
+  --volume /root/ros_home/.ros:/map \
+  -p 5000:5000 \
+  ghcr.io/nitescuc/openmower-mapeditor:main
+```
+
+After saving the map, `openmower` service will need to restarted to load the new map:
+
+```
+sudo systemctl restart openmower
+```


### PR DESCRIPTION
This setups GitHub Actions workflow that publishes multi-platform (Linux and Raspberry PI) docker image on every pull request and commit to the `main` branch.

Also adds instruction on how to run `openmower-mapeditor` docker image inside the OpenMower.